### PR TITLE
fix edge case where array_unique adds non-linear index 

### DIFF
--- a/src/Form/ChoiceMaskType.php
+++ b/src/Form/ChoiceMaskType.php
@@ -29,7 +29,7 @@ class ChoiceMaskType extends AbstractType
             }
         }
 
-        $view->vars['all_fields'] = array_unique($allFieldNames);
+        $view->vars['all_fields'] = array_values(array_unique($allFieldNames));
         $view->vars['map'] = $sanitizedMap;
 
         $options['expanded'] = false;


### PR DESCRIPTION
In some cases it can happen that `array_unique` adds non linear index to the array, which causes a js error in `forEach` in frontend, because the variable is treated as an `object` by js in this case and no longer as an `Array`.