### PR TITLE
Allow symfony/psr-http-message-bridge 6.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "symfony/options-resolver": "^5.4 || ^6.0",
         "easycorp/easyadmin-bundle": "^3.4 || ^v4.0",
         "stof/doctrine-extensions-bundle": "^1.6",
-        "symfony/psr-http-message-bridge": "^2.0",
+        "symfony/psr-http-message-bridge": "^2.0 || ^6.4",
         "nyholm/psr7": "^1.4",
         "embed/embed": "^4.2"
     },


### PR DESCRIPTION
It was moved to the main Symfony repository in version 6.4